### PR TITLE
Update ContactPick.java

### DIFF
--- a/src/android/ContactPick.java
+++ b/src/android/ContactPick.java
@@ -3,9 +3,9 @@ package com.mobitel.nalaka.piccon;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
-import org.apache.cordova.api.CallbackContext;
-import org.apache.cordova.api.CordovaPlugin;
-import org.apache.cordova.api.PluginResult;
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.PluginResult;
 import org.json.JSONException;
 import org.json.JSONObject;
 


### PR DESCRIPTION
Removed `.api` segment of Cordova class paths, to match their new locations. http://cordova.apache.org/docs/en/4.0.0/guide_platforms_android_plugin.md.html#Android%20Plugins
